### PR TITLE
Asset schema: drop webcomponent flag

### DIFF
--- a/json-schema/web_assets.json
+++ b/json-schema/web_assets.json
@@ -42,10 +42,6 @@
         "version": {
           "description": "Version of the asset item",
           "type": "string"
-        },
-        "webcomponent": {
-          "description": "A boolean flag set to 'true' if the asset item is a WebComponent, otherwise can be ignored",
-          "type": "boolean"
         }
       },
       "required": ["name", "type"]


### PR DESCRIPTION
Since https://github.com/joomla/joomla-cms/pull/32171 the `webcomponent` flag makes no sense now.